### PR TITLE
removed a loop from StrStream.match(wstring)

### DIFF
--- a/source/parser/lexer.d
+++ b/source/parser/lexer.d
@@ -333,9 +333,8 @@ class StrStream
         if (index + str.length > this.str.length)
             return false;
 
-        for (int i = 0; i < str.length; ++i)
-            if (str[i] != this.str[index+i])
-                return false;
+        if (str != this.str[index .. index+str.length])
+            return false;
 
         // Consume the characters
         for (int i = 0; i < str.length; ++i)


### PR DESCRIPTION
Strings can be directly compared, almost always faster than looping over them.
