### PR TITLE
switching to appender example

### DIFF
--- a/source/parser/ast.d
+++ b/source/parser/ast.d
@@ -78,18 +78,20 @@ class ASTProgram : FunExpr
     {
         auto blockStmt = cast(BlockStmt)bodyStmt;
         auto stmts = blockStmt.stmts;
+        
+        if(stmts.length == 0)
+            return "";
 
-        string str;
+        auto str = appender!string();
 
-        for (size_t i = 0; i < stmts.length; ++i)
+        foreach (stmt; stmts[0 .. $-1])
         {
-            auto stmt = stmts[i];
             str ~= stmt.toString();
-            if (i < stmts.length - 1)
-                str ~= "\n";
+            str ~= "\n";
         }
+        str ~= stmts[$-1].toString();
 
-        return str;
+        return str.data;
     }
 }
 


### PR DESCRIPTION
There is a lot of builtin array ~ appending in parser/*

A mixture of pre-allocation (where possible), use of std.array.appender and removal of logic from loops (again, where possible) could improve performance without adding very much code or obfuscating the logic.

This is simple example of what I'm imagining, just to illustrate the point. If you think the level of added code complexity is acceptable, i'll go ahead and rework the other similar situations with this style code.
