### PR TITLE
Fixing bug in RegEx back reference implementation.

### DIFF
--- a/source/stdlib/regexp.js
+++ b/source/stdlib/regexp.js
@@ -584,7 +584,7 @@ RegExpParser.prototype.parseAtomEscape = function ()
 {
     var cc;
 
-    if (this.current() >= 48 && this.current() <= 57)
+    if (this.current() >= 49 && this.current() <= 57)
     {
         return new RegExpBackReference( this.parseDecimalDigit() );
     }
@@ -673,6 +673,10 @@ RegExpParser.prototype.parseAtomEscape = function ()
             case 114: // 'r'
             this.advance();
             return new RegExpPatternCharacter(13);
+
+            case 48: // null character
+            this.advance();
+            return new RegExpPatternCharacter(0);
 
             default:
             var c = this.current();

--- a/source/tests/stdlib_regexp/stdlib_regexp.js
+++ b/source/tests/stdlib_regexp/stdlib_regexp.js
@@ -212,6 +212,15 @@ function test_backreference ()
 
 }
 
+function test_null_charcter ()
+{
+    if (!check_equal_matches(new RegExp("\\0").exec("test\0str"), ["\0"]))
+        return 1;
+    if (!check_equal_matches(new RegExp("\\0").exec("test str"), null))
+        return 2;
+    return 0;
+}
+
 function test ()
 {
     var r;
@@ -243,6 +252,10 @@ function test ()
     r = test_backreference();
     if (r !== 0)
         return 700 + r;
+
+    r = test_null_charcter();
+    if (r !== 0)
+        return 800 + r;
 
     return 0;
 }


### PR DESCRIPTION
\0 is null character and it was being handled as backreference.
