### PR TITLE
Fixed bug in regex which was causing some issues on AES crypto benchmark...

### DIFF
--- a/source/stdlib/regexp.js
+++ b/source/stdlib/regexp.js
@@ -71,6 +71,16 @@ RegExpParser.prototype.current = function ()
 } 
 
 /**
+Look ahead one character code.
+*/
+RegExpParser.prototype.lookAhead = function ()
+{
+    return this.index === this.pattern.length - 1 ?
+            null :
+            this.pattern.charCodeAt(this.index + 1);
+}
+
+/**
 Advance cursor one character.
 */
 RegExpParser.prototype.advance = function ()
@@ -815,7 +825,7 @@ RegExpParser.prototype.parseClassAtom = function ()
         this.advance();
     }
 
-    if (this.current() === 45) // '-'
+    if (this.current() === 45 && this.lookAhead() !==  93) // '-]'
     {
         this.advance();
         switch (this.current())
@@ -823,9 +833,6 @@ RegExpParser.prototype.parseClassAtom = function ()
             case 92: // '\'
             this.advance();
             node.max = this.parseAtomEscape();
-            break;
-
-            case 93: // ']'
             break;
 
             default:

--- a/source/tests/stdlib_regexp/stdlib_regexp.js
+++ b/source/tests/stdlib_regexp/stdlib_regexp.js
@@ -221,6 +221,21 @@ function test_null_charcter ()
     return 0;
 }
 
+function test_hyphen_character ()
+{
+    //print(new RegExp("[-djhd]").exec("xabcx-"));
+    if (!check_equal_matches(/-/g.exec("somestring-inthe"),["-"]))
+        return 1;
+    if (!check_equal_matches(/a-c/g.exec("a-cabc"),["a-c"]))
+        return 2;
+    if (!check_equal_matches(/[-xyz]/g.exec("somestring-inthe"),["-"]))
+        return 3;
+    if (!check_equal_matches(/[xz-]/g.exec("somestring-inthe"),["-"]))
+        return 4;
+
+    return 0;
+}
+
 function test ()
 {
     var r;
@@ -256,6 +271,10 @@ function test ()
     r = test_null_charcter();
     if (r !== 0)
         return 800 + r;
+
+    r = test_hyphen_character();
+    if (r !== 0)
+        return 900 + r;
 
     return 0;
 }


### PR DESCRIPTION
Class with end hyphen ( - ) was not being parsed. Added tests too.
