### PR TITLE
ffi.os

### DIFF
--- a/source/ir/ast.d
+++ b/source/ir/ast.d
@@ -2147,28 +2147,6 @@ IRValue refToIR(
         return new IRRawPtr(null);
     }
 
-    // If this is the os name constant
-    else if (identExpr.name == "$os")
-    {
-        wstring osName;
-
-        // NOTE: this just reports all BSDs as "BSD"
-        version (linux)
-            osName = "LINUX";
-        version (OSX)
-            osName = "OSX";
-        version (FreeBSD)
-            osName = "BSD";
-        version (NetBSD)
-            osName = "BSD";
-        version (DragonFlyBSD)
-            osName = "BSD";
-        version (BSD)
-            osName = "BSD";
-
-        return ctx.strVal(osName);
-    }
-
     // If the variable is global
     else if (identExpr.declNode is null)
     {

--- a/source/lib/ffi.js
+++ b/source/lib/ffi.js
@@ -2022,7 +2022,7 @@ FFI - provides functionality for writing bindings to/wrappers for C code.
     /**
     OS name
     */
-    var os = $os;
+    var os = string($ir_load_rawptr($ir_get_sym(c.handle, "higgs_osName"), 0));
 
     /**
     EXPORTS

--- a/source/main.d
+++ b/source/main.d
@@ -43,6 +43,7 @@ import std.string;
 import parser.parser;
 import runtime.vm;
 import util.string;
+import util.os;
 import repl;
 import options;
 

--- a/source/makefile
+++ b/source/makefile
@@ -20,6 +20,7 @@ util/id.d           \
 util/string.d       \
 util/misc.d         \
 util/bitset.d       \
+util/os.d           \
 parser/lexer.d      \
 parser/ast.d        \
 parser/vars.d       \

--- a/source/util/os.d
+++ b/source/util/os.d
@@ -1,0 +1,55 @@
+/*****************************************************************************
+*
+*                      Higgs JavaScript Virtual Machine
+*
+*  This file is part of the Higgs project. The project is distributed at:
+*  https://github.com/maximecb/Higgs
+*
+*  Copyright (c) 2013, Maxime Chevalier-Boisvert. All rights reserved.
+*
+*  This software is licensed under the following license (Modified BSD
+*  License):
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions are
+*  met:
+*   1. Redistributions of source code must retain the above copyright
+*      notice, this list of conditions and the following disclaimer.
+*   2. Redistributions in binary form must reproduce the above copyright
+*      notice, this list of conditions and the following disclaimer in the
+*      documentation and/or other materials provided with the distribution.
+*   3. The name of the author may not be used to endorse or promote
+*      products derived from this software without specific prior written
+*      permission.
+*
+*  THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+*  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+*  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+*  NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+*  NOT LIMITED TO PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+*  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+*****************************************************************************/
+
+module util.os;
+
+extern (C)
+{
+    // NOTE: this just reports all BSDs as "BSD"
+    version (linux)
+        immutable (char*) higgs_osName = "LINUX";
+    version (OSX)
+         immutable (char*) higgs_osName = "OSX";
+    version (FreeBSD)
+         immutable (char*) higgs_osName = "BSD";
+    version (NetBSD)
+         immutable (char*) higgs_osName = "BSD";
+    version (DragonFlyBSD)
+         immutable (char*) higgs_osName = "BSD";
+    version (BSD)
+         immutable (char*) higgs_osName = "BSD";
+}


### PR DESCRIPTION
This adds a `ffi.os` property to determine what operating system higgs is running on; the value will be a string of either `LINUX`, `BSD`, or `OSX`. 
