### PR TITLE
Fix ffi parsing for short types

### DIFF
--- a/devnotes/TODO Tom.txt
+++ b/devnotes/TODO Tom.txt
@@ -1,7 +1,7 @@
 TODO: check out failing sunspider tests
       - string-validate-input segfaults
       - string-unpack-code has some odd bug
-      - string-tagcloud has some error in its parseJSON     
+      - string-tagcloud has some error in its parseJSON
 
 TODO: all libs
       - cleaner API designs

--- a/source/ir/iir.d
+++ b/source/ir/iir.d
@@ -128,6 +128,8 @@ static this()
     addOp(GE_I32);
     addOp(EQ_I8);
 
+    addOp(EQ_I64);
+
     addOp(EQ_REFPTR);
     addOp(NE_REFPTR);
 

--- a/source/ir/ops.d
+++ b/source/ir/ops.d
@@ -176,6 +176,8 @@ Opcode LE_I32 = { "le_i32", true, [OpArg.LOCAL, OpArg.LOCAL], &gen_le_i32, OpInf
 Opcode GE_I32 = { "ge_i32", true, [OpArg.LOCAL, OpArg.LOCAL], &gen_ge_i32, OpInfo.BOOL_VAL };
 Opcode EQ_I8 = { "eq_i8", true, [OpArg.LOCAL, OpArg.LOCAL], &gen_eq_i8, OpInfo.BOOL_VAL };
 
+Opcode EQ_I64 = { "eq_i64", true, [OpArg.LOCAL, OpArg.LOCAL], &gen_eq_i64, OpInfo.BOOL_VAL };
+
 // Pointer comparison instructions
 Opcode EQ_REFPTR = { "eq_refptr", true, [OpArg.LOCAL, OpArg.LOCAL], &gen_eq_refptr, OpInfo.BOOL_VAL };
 Opcode NE_REFPTR = { "ne_refptr", true, [OpArg.LOCAL, OpArg.LOCAL], &gen_ne_refptr, OpInfo.BOOL_VAL };

--- a/source/jit/ops.d
+++ b/source/jit/ops.d
@@ -1443,6 +1443,9 @@ alias CmpOp!("lt", 32) gen_lt_i32;
 alias CmpOp!("le", 32) gen_le_i32;
 alias CmpOp!("gt", 32) gen_gt_i32;
 alias CmpOp!("ge", 32) gen_ge_i32;
+
+alias CmpOp!("eq", 64) gen_eq_i64;
+
 alias CmpOp!("eq", 8) gen_eq_const;
 alias CmpOp!("ne", 8) gen_ne_const;
 alias CmpOp!("eq", 64) gen_eq_refptr;

--- a/source/lib/ffi.js
+++ b/source/lib/ffi.js
@@ -448,17 +448,10 @@ FFI - provides functionality for writing bindings to/wrappers for C code.
                 this.acceptEnumSpecifier();
             else if (type === TYPE_SPECIFIER)
                 if (dec.type)
-                    if (tok === "char" || tok === "int" || tok === "long")
-                    {
+                    if (tok === "char" || tok === "int" || tok === "long" || tok === "short")
                         dec.type = CType(dec.type.name + " " + tok);
-                    }
                     else
-                    {
-                        if (dec.storage_class === "typedef")
-                            dec.name = tok;
-                        else
-                            throw new CParseUnexpectedError("type specifier", tok, lex.loc());
-                    }
+                        throw new CParseUnexpectedError("type specifier", tok, lex.loc());
                 else
                     dec.type = CType(tok);
             else if (type === TYPE_QUALIFIER)
@@ -1453,6 +1446,7 @@ FFI - provides functionality for writing bindings to/wrappers for C code.
     CType("unsigned short int", "u16", 2, "$ir_load_u16", "$ir_store_u16");
 
     CType("int", "i32", 4, "$ir_load_i32", "$ir_store_i32");
+    CType("signed", "i32", 4, "$ir_load_i32", "$ir_store_i32");
     CType("signed int", "i32", 4, "$ir_load_i32", "$ir_store_i32");
     CType("unsigned", "u32", 4, "$ir_load_u32", "$ir_store_u32");
     CType("unsigned int", "u32", 4, "$ir_load_u32", "$ir_store_u32");

--- a/source/runtime/ffitests.d
+++ b/source/runtime/ffitests.d
@@ -57,6 +57,7 @@ version (FFIdev)
 // Dummy functions used for FFI tests
 version (TestFFI)
 {
+
     // Used to test the low-level FFI ops
     extern (C)
     {
@@ -138,6 +139,32 @@ version (TestFFI)
         {
             return HelloWorld.ptr;
         }
+
+
+        // issue #102
+        alias ulong __uint64_t;
+        alias uint __uint32_t;
+        alias ushort __uint16_t;
+        alias ubyte __uint8_t;
+
+        struct TestDir {
+            __uint64_t d_fileno;
+            __uint16_t d_seekoff;
+            __uint16_t d_reclen;
+            __uint16_t d_namlen;
+            __uint8_t  d_type;
+            char       d_name[1024];
+        }
+
+        static TestDir TestDirEnt = {
+            d_fileno: 1,
+            d_seekoff: 2,
+            d_reclen: 3,
+            d_namlen: 4,
+            d_type: 5,
+            d_name: "foo"
+        };
+
     }
 }
 

--- a/source/tests/08-lib/ffi.js
+++ b/source/tests/08-lib/ffi.js
@@ -90,3 +90,28 @@ assertEq(ffi.string(c.getTestString()), "Hello World!");
 // Test os name
 var os = ffi.os;
 assertTrue(os === "LINUX" || os === "BSD" || os === "OSX");
+
+// issue #102 regression
+c.cdef(`
+       typedef unsigned long long  __uint64_t;
+       typedef unsigned int        __uint32_t;
+       typedef unsigned short      __uint16_t;
+       typedef unsigned char       __uint8_t;
+       struct direntBSD {
+           __uint64_t d_fileno;
+           __uint16_t d_seekoff;
+           __uint16_t d_reclen;
+           __uint16_t d_namlen;
+           __uint8_t  d_type;
+           char       d_name[1024];
+       };
+       struct direntBSD TestDirEnt;
+`);
+
+var testdir = c.TestDirEnt;
+assertTrue($ir_eq_i64(1, testdir.get_d_fileno()));
+assertEq(testdir.get_d_seekoff(), 2);
+assertEq(testdir.get_d_reclen(), 3);
+assertEq(testdir.get_d_namlen(), 4);
+assertEq(testdir.get_d_type(), 5);
+assertEq(testdir.d_name.toString(), "foo");


### PR DESCRIPTION
I tried recreating issue #102 on my system and hit this bug. Here's a fix and a regression test. Also adds an eq comp op for i64s.
