### PR TITLE
fix improper handling of fun.apply(null,...)

### DIFF
--- a/source/stdlib/function.js
+++ b/source/stdlib/function.js
@@ -216,6 +216,11 @@ Function.prototype.apply = function (thisArg, argArray)
     if (!$ir_is_array(argArray))
         throw new TypeError('invalid arguments array');
 
+    // If the this argument is null or undefined,
+    // make it the global object
+    if (thisArg === null || thisArg === undefined)
+        thisArg = $ir_get_global_obj();
+
     // Get the arguments table from the array
     var argTable = $rt_arr_get_tbl(argArray);
 
@@ -233,11 +238,6 @@ Function.prototype.apply = function (thisArg, argArray)
 */
 Function.prototype.call = function (thisArg)
 {
-    // If the this argument is null or undefined,
-    // make it the global object
-    if (thisArg === null || thisArg === undefined)
-        thisArg = $ir_get_global_obj();
-
     var argArray = [];
     for (var i = 1; i < $argc; ++i)
         argArray.push($ir_get_arg(i));

--- a/source/tests/core/apply/apply.js
+++ b/source/tests/core/apply/apply.js
@@ -82,6 +82,11 @@ function foo7(i,x)
     this[i] = x;
 }
 
+function foo8()
+{
+    return this;
+}
+
 function test()
 {
     if (foo.apply(undefined, []) !== undefined)
@@ -124,6 +129,11 @@ function test()
     if (a[42] !== 1337)
     {
         return 8;
+    }
+
+    if (foo8.apply(null, []) !== $ir_get_global_obj())
+    {
+        return 9;
     }
 
     return 0;


### PR DESCRIPTION
```
- fix improper handling of fun.apply(null,...)
- add regression test for fun.apply(null,...)
```

fun.apply(null,[]) was being handled incorrectly and it was causing an error in the sunspider benchmark `string-unpack-code.js`. This fixes that, however there is another problem in the benchmark.
