### PR TITLE
Fix the RegExp constructor.

### DIFF
--- a/source/stdlib/regexp.js
+++ b/source/stdlib/regexp.js
@@ -877,6 +877,8 @@ function RegExp (
     flags
 )
 {
+    if (!(this instanceof RegExp)) return new RegExp(pattern, flags);
+    
     this.source = (pattern === undefined ? "" : pattern);
     this.global = false;
     this.ignoreCase = false;

--- a/source/tests/01-stdlib/regexp.js
+++ b/source/tests/01-stdlib/regexp.js
@@ -236,6 +236,12 @@ function test_hyphen_character ()
     return 0;
 }
 
+function test_constructor ()
+{
+    assert(RegExp(/[a-z]/) instanceof RegExp);
+    assert(new RegExp(/[a-z]/) instanceof RegExp);
+}
+
 function test ()
 {
     var r;
@@ -275,6 +281,8 @@ function test ()
     r = test_hyphen_character();
     if (r !== 0)
         return 900 + r;
+    
+    test_constructor();
 
     return 0;
 }


### PR DESCRIPTION
When called as a function, the RegExp constructor did not work properly. This commit makes it instantiate itself when called as a function.
