### PR TITLE
Issue 124 - String.prototype.split()

### DIFF
--- a/devnotes/TODO Tommy.txt
+++ b/devnotes/TODO Tommy.txt
@@ -2,7 +2,12 @@ TODO: check out failing sunspider tests
       X string-validate-input segfaults
       X string-unpack-code has some odd bug
       X string-tagcloud has some error in its parseJSON
-      - date-format-tofte  - problem with eval?
+      - date-format-tofte fails due to eval - issue #112
+
+TODO: spec-compliance
+      - open issue for String.prototype.split - not spec compliant wrt regexps etc
+      - search for other stdlib functions that fail spec
+      - open issue for parsing wrt reserved words in objects
 
 TODO: all libs
       - cleaner API designs

--- a/source/stdlib/string.js
+++ b/source/stdlib/string.js
@@ -589,24 +589,50 @@ function string_search(regexp)
 function string_split(separator, limit)
 {
     var res = new Array();
-    if (limit === 0) return res;
-
     var len = this.length;
-    if (len === 0) return res;
 
-    if (separator === undefined)
-        return [this];
+    // special cases
+    if (limit === 0)
+    {
+        return res;
+    }
+    else if (separator === undefined)
+    {
+        res[0] = this;
+        return res;
+    }
 
-    var pos = this.indexOf(separator);
+    var sep = separator + "";
+    var this_blank = (len === 0);
+    var sep_blank = (sep.length === 0);    
+
+    // special cases
+    if (this_blank)
+    {
+        if (sep_blank)
+            return res;
+
+        res[0] = this;
+        return res;
+    }
+    else if (sep_blank)
+    {
+        for (var i = 0; i < len; i ++)
+            res[i] = this[i];
+
+        return res;
+    }
+
+    var pos = this.indexOf(sep);
     var start = 0;
-    var sepLen = separator.length;
+    var sepLen = sep.length;
 
     while (pos >= 0)
     {
         res.push(this.substring(start, pos));
         if (res.length === limit) return res;
         start = pos + sepLen;
-        pos = this.indexOf(separator, pos + sepLen);
+        pos = this.indexOf(sep, pos + sepLen);
     }
 
     if (start <= len)

--- a/source/tests/01-stdlib/string.js
+++ b/source/tests/01-stdlib/string.js
@@ -313,6 +313,27 @@ function test_split()
     if (!array_eq('foo,bar,bif'.split(), ['foo,bar,bif']))
         return 6;
 
+    if (!array_eq('foo'.split(''), ['f', 'o', 'o']))
+        return 7;
+
+    if (!array_eq('foonull'.split(null), ['foo', '']))
+        return 8;
+
+    if (!array_eq(''.split('f'), ['']))
+        return 9;
+
+    if (!array_eq(''.split(''), []))
+        return 10;
+
+    if (!array_eq('181'.split(8), ['1','1']))
+        return 11;
+
+    if (!array_eq('181'.split({toString : function(){ return '8';}}), ['1','1']))
+        return 12;
+
+    if (!array_eq('181'.split([8]), ['1','1']))
+        return 12;
+
     return 0;
 }
 


### PR DESCRIPTION
This PR comprises some fixes to bring String.prototype.split() wrt the things outlined in issue #124. It's still not fully compliant due to regex stuff, but that will have to be handled later.

This solves the memory consumption problem outlined in issue #112.

closes #124
