### PR TITLE
x11 exports typo

### DIFF
--- a/source/lib/x11.js
+++ b/source/lib/x11.js
@@ -2926,7 +2926,7 @@ NOTE: currently this provides just enough bindings for the drawing lib
     };
 
     /* EXPORT */
-    foreach (name in Xlib)
+    for (name in Xlib)
         exports[name] = Xlib[name];
 
 })(exports);


### PR DESCRIPTION
`run-time error: run-time error: "global property not defined "foreach" '
