### PR TITLE
Fix uint64_t casting in murmurHash64A

### DIFF
--- a/source/runtime/string.d
+++ b/source/runtime/string.d
@@ -105,7 +105,7 @@ uint64_t murmurHash64A(const void* key, size_t len, uint64_t seed = 1337)
 
 	uint64_t h = seed ^ (len * m);
 
-    uint64_t* data = cast(uint64_t*)key;
+  uint64_t* data = cast(uint64_t*)key;
 	uint64_t* end = data + (len/8);
 
 	while (data != end)
@@ -124,13 +124,13 @@ uint64_t murmurHash64A(const void* key, size_t len, uint64_t seed = 1337)
 
 	switch (len & 7)
 	{
-	    case 7: h ^= uint64_t(tail[6]) << 48;
-	    case 6: h ^= uint64_t(tail[5]) << 40;
-	    case 5: h ^= uint64_t(tail[4]) << 32;
-	    case 4: h ^= uint64_t(tail[3]) << 24;
-	    case 3: h ^= uint64_t(tail[2]) << 16;
-	    case 2: h ^= uint64_t(tail[1]) << 8;
-	    case 1: h ^= uint64_t(tail[0]);
+	    case 7: h ^= cast(uint64_t) tail[6] << 48;
+	    case 6: h ^= cast(uint64_t) tail[5] << 40;
+	    case 5: h ^= cast(uint64_t) tail[4] << 32;
+	    case 4: h ^= cast(uint64_t) tail[3] << 24;
+	    case 3: h ^= cast(uint64_t) tail[2] << 16;
+	    case 2: h ^= cast(uint64_t) tail[1] << 8;
+	    case 1: h ^= cast(uint64_t) tail[0];
 	            h *= m;
         default:
 	};


### PR DESCRIPTION
This fixed a problem in casting in the murmurHash2 definition. The unint64_t casting function is not available, generating an error during compilation.
