### PR TITLE
Add memory to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A JIT compiler for JavaScript targetting x86-64 platforms.
 - POSIX compliant OS (Linux, Unix, MacOS X)
 - Python 2.7 (if regenerating object layouts)
 - x86 64-bit CPU
+- 2.5 Gb memory
 - GNU make
 - GNU time
 


### PR DESCRIPTION
My build VM with 1 gb failed to compile. `make all` told "out of memory". I increased memory step by step and compiled successfully with 2.5 gb. Maybe add to requirements?
