### PR TITLE
Add an install-dev option to the makefile + documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ make install BIN_DIR=/my/bin/dir LIB_DIR=/my/lib/dir
 
 NOTE: you may need to run `make install` with `sudo`.
 
+`make install-dev`
+is essentially the same thing as `make install`, but instead of copying the `runtime`, `stdlib` and `lib` in the `LIB_DIR` folder, it creates a symbolic link to the ones in your git folder.
+
 *Cleanup:*
 
 `make clean`

--- a/source/makefile
+++ b/source/makefile
@@ -104,3 +104,9 @@ install: release
 	cp -R ./lib/* $(LIB_DIR)/lib
 	cp $(BIN_NAME) $(BIN_DIR)
 
+install-dev: release
+	@if [ ! -d $(LIB_DIR) ] ; then echo "mkdir $(LIB_DIR)" ; mkdir $(LIB_DIR) ; fi
+	ln -s $(CURDIR)/runtime/ $(LIB_DIR)/runtime
+	ln -s $(CURDIR)/stdlib/ $(LIB_DIR)/stdlib
+	ln -s $(CURDIR)/lib/ $(LIB_DIR)/lib
+	cp $(BIN_NAME) $(BIN_DIR)


### PR DESCRIPTION
Install higgs using symbolic links instead of copying the files.
