### PR TITLE
Create an Options Parser.

### DIFF
--- a/examples/options.js
+++ b/examples/options.js
@@ -1,0 +1,43 @@
+var Options = require('lib/options').Options;
+var console = require('lib/console')
+
+var o = Options()
+    // turn on automatic display of help
+    .autoHelp()
+    // turn on automatic display of version
+    .autoVersion()
+    // set version number
+    .version('1.0.0')
+    // set the usage string
+    .usage('file1, file2, fileN')
+    // long option only
+    .add('long', null, null, 'long option.')
+    // long and short option
+    .add('double', null, null, 'long and short option', 'd')
+    // short option only
+    .add(null, null, null, 'short option.', 's')
+    //    long    defult  type          description         short   required
+    .add('param', 13.37, '+float', 'a positive float value', 'p', true);
+
+// alternate construction
+// var o = Options({
+//     autoHelp: true,
+//     autoVersion: true,
+//     version: '1.0.0',
+//     usage: 'file1, file2, fileN',
+//     opts: [
+//         {long: 'long', desc: 'long option'},
+//         {long: 'double', short: 'd', desc: 'long and short option'},
+//         {short: 's', desc: 'short option'},
+//         {long: 'param', defval: 13.37, type: '+float', desc: 'a positive float value', short: 'p', req: true},
+//     ],
+// });
+
+// Values are converted and added to the result object.
+// Both the long and short option will contain the value.
+// The plain arguments are placed in an array that
+// can be accessed via the _ property on the result.
+var r = o.parse(arguments);
+
+// display the resulting object
+console.log(r);

--- a/source/lib/options.js
+++ b/source/lib/options.js
@@ -1,0 +1,493 @@
+/**
+    Features:
+     - Argument collection
+     - Long options: --long
+     - Short options: -s
+     - Option description
+     - Default values
+     - Type checking and error reporting
+     - Available types: string, boolean, int, +int, float, +float
+     - Type inference using the default value (when provided)
+     - Automatic convertion of types (from strings)
+     - Mandatory options and error reporting
+     - Automatic help and version display (when turned on)
+
+    Parsing:
+        Values are assigned using an equal sign.
+            --opt=val, -o=val
+        Short options can be grouped together. The last
+        option of a short option group can have a value:
+            -abc=def c gets the value 'def'
+
+         -a             => {a: true}
+         -a=value       => {a: 'value'}
+         -ab            => {a: true, b: true}
+         -ab=value      => {a: true, b: 'value'}
+         --long=value   => {long: 'value'}
+
+         Anything that is not preceded by an option is considered
+         a plain argument.
+ */
+
+(function (exports) {
+
+    var exit = require('lib/stdlib').exit;
+
+    /**
+     * Create a new options parser.
+     * config: (optional)
+     */
+    function Options(config)
+    {
+        if (!(this instanceof Options)) return new Options(config);
+        this._usage = null;
+        this._version = null;
+        this._specs = [];
+
+        this.helpSpec = {long: 'help', short: null, desc: 'display this help and exit', defval: false, type: 'boolean'};
+        this.versionSpec = {long: 'version', short: null, desc: "output version information and exit", defval: false, type: 'boolean'};
+
+        if (config != null)
+        {
+            this._usage = config.usage;
+            this._version = config.version;
+            this._autoHelp = config.autoHelp;
+            this._autoVersion = config.autoVersion;
+            for (var i = 0; i < config.opts.length; i++)
+            {
+                var opt = config.opts[i];
+                this.add(opt.long, opt.defval, opt.type, opt.desc, opt.short, opt.req);
+            }
+        }
+    }
+
+    /**
+     * usage: usage string
+     */
+    Options.prototype.usage = function (usage)
+    {
+        this._usage = usage;
+        return this;
+    };
+
+    /**
+     * version: version string
+     */
+    Options.prototype.version = function (version)
+    {
+        this._version = version;
+        return this;
+    };
+
+    /**
+     * Turn automatic display of help on or off.
+     * on: (optional, defaults to true)
+     */
+    Options.prototype.autoHelp = function (on)
+    {
+        if (on == null) on = true;
+        this._autoHelp = on;
+        return this;
+    };
+
+    /**
+     * Turn automatic display of version on of off.
+     * on: (optional, defaults to true)
+     */
+    Options.prototype.autoVersion = function (on)
+    {
+        if (on == null) on = true;
+        this._autoVersion = on;
+        return this;
+    }
+
+    /**
+     * Format a spec for display.
+     */
+    function formatSpec(spec)
+    {
+        if (spec.long != null && spec.short != null)
+            return '--' + spec.long + ', ' + '-' + spec.short;
+        else if (spec.long != null)
+            return '--' + spec.long;
+        else if (spec.short != null)
+            return '-' + spec.short;
+    }
+
+    /**
+     * Add padding for indentation purposes.
+     */
+    function appendSpaces(str, longest)
+    {
+        var len = Math.max(0, longest - str.length);
+        return str + Array(len + 1).join(' ');
+    }
+
+    /**
+     * Display help about command.
+     */
+    Options.prototype.help = function ()
+    {
+        var buff = '';
+        var specs = this._getSpecs();
+
+        if (this._usage != null)
+            buff += '\nUsage: ' + this._usage +'\n';
+
+        if (specs.length > 0)
+        {
+            var longestLeft = 0;
+            var lefts = [];
+
+            buff += '\nOptions:\n\n';
+
+            // format left part of help
+            for (var i = 0; i < specs.length; i++)
+            {
+                var left = formatSpec(specs[i]);
+
+                // record which left is the longest for padding
+                longestLeft = Math.max(longestLeft, left.length);
+                lefts.push(left);
+            }
+
+            // create the lines
+            for (var i = 0; i < specs.length; i++)
+            {
+                var spec = specs[i];
+                var line = '    ' + appendSpaces(lefts[i], longestLeft);
+                if (spec.desc != null)
+                    line += '    ' + spec.desc;
+                buff += line + '\n';
+            }
+        }
+
+        print(buff);
+    };
+
+    /**
+     * long: long option name
+     * short: short option name
+     * desc: description of option
+     * defval: default value
+     * type: type of data (valid types: string, int, +int, float, +float, boolean)
+     * req: required
+     */
+    Options.prototype.add = function (long, defval, type, desc, short, req)
+    {
+        // try to infer the type when possible
+        if (type == null)
+        {
+            if (defval == null)
+            {
+                type = 'string';
+            }
+            else
+            {
+                // infer from default value
+                if ($ir_is_string(defval))
+                    type = 'string';
+                else if ($ir_is_int32(defval))
+                    type = 'int';
+                else if ($ir_is_float64(defval))
+                    type = 'float';
+                else if (typeof defval === 'boolean')
+                    type = 'boolean';
+            }
+        }
+
+        this._specs.push({
+            long: long,
+            short: short,
+            desc: desc,
+            defval: defval,
+            type: type,
+            req: req,
+        });
+
+        return this;
+    };
+
+    /**
+     * Get the list of specs and append the helpSpec and versionSpec if they're activated.
+     */
+    Options.prototype._getSpecs = function ()
+    {
+        var arr = this._specs.slice();
+        if (this._autoHelp)
+            arr = arr.concat(this.helpSpec);
+        if (this._autoVersion && this._version != null)
+            arr = arr.concat(this.versionSpec);
+        return arr;
+    };
+
+    /**
+     * arg: argument to parse
+     * options: options object to modify
+     */
+    function parseOption(arg, options)
+    {
+        // long option regex
+        var matches = arg.match(/^--([a-z0-9_\-]+)(?:=(.+))?$/i);
+        if (matches !== null)
+        {
+            options[matches[1]] = matches[2] || true;
+        }
+        else
+        {
+            // short option regex
+            matches = arg.match(/^-([a-z]+)(?:=(.+))?$/i);
+            // check if parameter is valid
+            if (matches !== null)
+            {
+                // split the options -abc = {a:true,b:true,c:true}
+                for (var i = 1; i < arg.length; i++)
+                    options[arg[i]] = true;
+                // if there's a value, give it to the last option
+                // -abc=qwerty {a:true,b:true,c:'qwerty'}
+                if (matches[2] != null)
+                {
+                    var opt = matches[1].slice(-1);
+                    options[opt] = matches[2];
+                }
+            } else {
+                throw new Error('Invalid option: ' + arg);
+            }
+        }
+    }
+    exports._parseOption = parseOption;
+
+    /**
+     * argv: argument vector, list of arguments
+     */
+    function parseArgv(argv)
+    {
+        var arguments = [];
+        var options = {};
+        for (var i = 0; i < argv.length; i++)
+        {
+            var arg = argv[i];
+            if (/^--?/.test(arg))
+            {
+                parseOption(arg, options);
+            }
+            else
+            {
+                arguments.push(arg);
+            }
+        }
+        return {args: arguments, opts: options};
+    }
+    exports._parseArgv = parseArgv;
+
+    /**
+     * Anything is valid.
+     */
+    function testString()
+    {
+        return true;
+    }
+
+    /**
+     *    33 | -33
+     *   33. | -33.
+     *   .33 | -.33
+     * 33.33 | -33.33
+     */
+    function testFloat(val)
+    {
+        return /^\-?([0-9]+|[0-9]+\.|\.[0-9]+|[0-9]+\.[0-9]+)$/.test(val);
+    }
+    exports._testFloat = testFloat;
+
+    /**
+     * Same as testFloat, but no negative numbers.
+     */
+    function testFloatPositive(val)
+    {
+        return /^([0-9]+|[0-9]+\.|\.[0-9]+|[0-9]+\.[0-9]+)$/.test(val);
+    }
+    exports._testFloatPositive = testFloatPositive;
+
+    /**
+     * 33 | -33
+     */
+    function testInt(val)
+    {
+        return /^\-?[0-9]+$/.test(val);
+    }
+    exports._testInt = testInt;
+
+    /**
+     * Same as testInt, but no negative numbers.
+     */
+    function testIntPositive(val)
+    {
+        return /^[0-9]+$/.test(val);
+    }
+    exports._testIntPositive = testIntPositive;
+
+    /**
+     * Accepts a boolean, or the strings 'on', 'yes', 'true', 'off', 'no', 'false'
+     */
+    function testBoolean(val)
+    {
+        if ($ir_is_string(val))
+            return /^(1|on|yes|true|0|off|no|false)$/i.test(val);
+        else if (typeof val === 'boolean')
+            return true;
+        return false;
+    }
+    exports._testBoolean = testBoolean;
+
+    /**
+     * Data validity tests by type.
+     */
+    var typeTests = {
+        'string': testString,
+        'float': testFloat,
+        '+float': testFloatPositive,
+        'int': testInt,
+        '+int': testIntPositive,
+        'boolean': testBoolean,
+    };
+
+    /**
+     * Map from type to "English" equivalent.
+     */
+    var typeToString = {
+        'string': 'a string',
+        'float': 'a floating point number',
+        '+float': 'a positive floating point number',
+        'int': 'an integer',
+        '+int': 'a positive integer',
+        'boolean': 'a boolean',
+    };
+
+    /**
+     * Convert the string value to the correct type when possible.
+     * val: string value
+     * type: type of value
+     */
+    function convertValue(val, type)
+    {
+        switch (type) {
+            case 'float':
+            case '+float':
+                return parseFloat(val);
+            case 'int':
+            case '+int':
+                return parseInt(val);
+            case 'boolean':
+                if ($ir_is_string(val))
+                {
+                    if (/^(1|on|yes|true)$/i.test(val)) return true;
+                    else if (/^(0|off|no|false)$/i.test(val)) return false;
+                }
+                return val;
+            default:
+                return val;
+        }
+    }
+    exports._convertValue = convertValue;
+
+    /**
+    * opts: options that were parsed
+    * spec: specification of the option
+    */
+    function getValue(opts, spec)
+    {
+        if (opts[spec.long] != null) return opts[spec.long];
+        if (opts[spec.short] != null) return opts[spec.short];
+        return null;
+    }
+
+    /**
+    * results: result object to modify
+    * spec: specification for the option
+    * val: value to apply
+    */
+    function applyValue(results, spec, val)
+    {
+        if (spec.long != null)
+        results[spec.long] = val;
+        if (spec.short != null)
+        results[spec.short] = val;
+    }
+
+    /**
+     * Print
+     * str: string to print
+     * code: return code (defaults to 1)
+     */
+    function printAndExit(str, code)
+    {
+        print(str);
+        exit(code != null ? code : 1);
+    }
+
+    /**
+     * args: command line arguments
+     *
+     * Accepted patterns for parameters:
+     *  -a             => {a: true}
+     *  -ab            => {a: true, b: true}
+     *  -ab=value      => {a: true, b: value}
+     *  --long=value   => {long: value}
+     */
+    Options.prototype.parse = function (argv)
+    {
+        var p = parseArgv(argv);
+        var opts = p.opts;
+        var results = {};
+        var specs = this._getSpecs();
+        for (var i = 0; i < specs.length; i++)
+        {
+            var spec = specs[i];
+            // check if long option is present
+            var val = getValue(opts, spec);
+
+            // if there is a value, use it
+            if (val != null)
+            {
+                // validate value
+                if (!typeTests[spec.type](val))
+                {
+                    printAndExit('Invalid type for ' + formatSpec(spec) + '. Expected ' + typeToString[spec.type] + ".");
+                }
+
+                // convert from string to spec.type
+                val = convertValue(val, spec.type);
+
+                applyValue(results, spec, val);
+            }
+            // fallback to default value if present
+            else if (spec.defval != null)
+            {
+                applyValue(results, spec, spec.defval);
+            }
+            else if (spec.req === true)
+            {
+                printAndExit('The option ' + formatSpec(spec) + ' is required.');
+            }
+        }
+
+        results._ = p.args;
+
+        if (this._autoHelp && results.help === true)
+        {
+            this.help();
+            exit(0);
+        }
+
+        if (this._autoVersion && this._version != null && results.version === true)
+        {
+            printAndExit(this._version, 0);
+        }
+
+        return results;
+    };
+
+    exports.Options = Options;
+
+})(exports);

--- a/source/tests/09-lib/options.js
+++ b/source/tests/09-lib/options.js
@@ -1,0 +1,152 @@
+if (typeof assertEq === 'undefined')
+{
+    require('lib/test.js');
+}
+
+var options = require('lib/options.js');
+
+function test_parseArgv()
+{
+    var argv = ['arg1', '--longbool', '--longval=val', '-abc', 'arg2', '-def=val'];
+
+    var p = options._parseArgv(argv);
+
+    assertEqArray(p.args, ['arg1', 'arg2']);
+
+    assert(p.opts.longbool);
+    assertEq(p.opts.longval, 'val');
+    assert(p.opts.a);
+    assert(p.opts.b);
+    assert(p.opts.c);
+    assert(p.opts.d);
+    assert(p.opts.e);
+    assertEq(p.opts.f, 'val');
+}
+
+function test_parse_result()
+{
+    var o = options.Options()
+        .add('long', null)
+        .add('double', null, null, null, 'd')
+        .add(null, null, null, null, 's');
+
+    var r = o.parse(['--long=val1', '-sd=val2', 'arg1', 'arg2', 'arg3']);
+
+    assertEqArray(r._, ['arg1', 'arg2', 'arg3']);
+    assertEq(r.long, 'val1');
+    assertEq(r.d, 'val2');
+    assertEq(r.double, 'val2');
+    assert(r.s);
+}
+
+function test_parse_defval()
+{
+    var o = options.Options()
+        .add('default', 'qwerty', null, null, 'D');
+
+    var r = o.parse([]);
+
+    assertEq(r.default, 'qwerty');
+    assertEq(r.D, 'qwerty');
+}
+
+function test_parse_convert()
+{
+    var o = options.Options()
+        .add('intval', null, 'int')
+        .add('floatval', null, 'float')
+        .add('yes', null, 'boolean')
+        .add('off', null, 'boolean')
+        .add('false', null, 'boolean')
+        .add('one', null, 'boolean');
+
+    var r = o.parse(['--intval=3', '--floatval=0.5', '--yes=yes', '--off=off', '--false=false', '--one=1']);
+
+    assertEq(r.intval, 3);
+    assertEq(r.floatval, 0.5);
+    assert(r.yes);
+    assert(!r.off);
+    assert(!r.false);
+}
+
+function test_testFloat()
+{
+    assert(options._testFloat('-33'));
+    assert(options._testFloat('33.'));
+    assert(options._testFloat('-.33'));
+    assert(options._testFloat('33.33'));
+    assert(!options._testFloat(''));
+    assert(!options._testFloat('.'));
+    assert(!options._testFloat('-.'));
+}
+
+function test_testFloatPositive()
+{
+    assert(options._testFloatPositive('33'));
+    assert(options._testFloatPositive('33.'));
+    assert(options._testFloatPositive('.33'));
+    assert(options._testFloatPositive('33.33'));
+    assert(!options._testFloatPositive(''));
+    assert(!options._testFloatPositive('.'));
+    assert(!options._testFloatPositive('-33.33'));
+}
+
+function test_testInt()
+{
+    assert(options._testInt('33'));
+    assert(options._testInt('-33'));
+    assert(!options._testInt('abc'));
+}
+
+function test_testIntPositive()
+{
+    assert(options._testIntPositive('33'));
+    assert(!options._testIntPositive('-33'));
+    assert(!options._testIntPositive('abc'));
+}
+
+function test_testBoolean()
+{
+    assert(options._testBoolean(true));
+    assert(options._testBoolean(false));
+    assert(options._testBoolean('on'));
+    assert(options._testBoolean('off'));
+    assert(options._testBoolean('1'));
+    assert(options._testBoolean('0'));
+    assert(options._testBoolean('yes'));
+    assert(options._testBoolean('no'));
+    assert(options._testBoolean('true'));
+    assert(options._testBoolean('false'));
+    assert(!options._testBoolean('this isnt boolean'));
+}
+
+function test_convertValue()
+{
+    assertEq(options._convertValue('3.14', 'float'), 3.14);
+    assertEq(options._convertValue('-3.14', 'float'), -3.14);
+    assertEq(options._convertValue('3.14', '+float'), 3.14);
+    assertEq(options._convertValue('3', 'int'), 3);
+    assertEq(options._convertValue('-3', 'int'), -3);
+    assertEq(options._convertValue('3', '+int'), 3);
+    assertEq(options._convertValue(true, 'boolean'), true);
+    assertEq(options._convertValue('1', 'boolean'), true);
+    assertEq(options._convertValue('on', 'boolean'), true);
+    assertEq(options._convertValue('yes', 'boolean'), true);
+    assertEq(options._convertValue('true', 'boolean'), true);
+    assertEq(options._convertValue(false, 'boolean'), false);
+    assertEq(options._convertValue('0', 'boolean'), false);
+    assertEq(options._convertValue('off', 'boolean'), false);
+    assertEq(options._convertValue('no', 'boolean'), false);
+    assertEq(options._convertValue('false', 'boolean'), false);
+}
+
+test_parseArgv();
+test_parse_result();
+test_parse_defval();
+test_parse_convert();
+test_testFloat();
+test_testFloatPositive();
+test_testInt();
+test_testIntPositive();
+test_testBoolean();
+test_convertValue();


### PR DESCRIPTION
    Features:
     - Argument collection
     - Long options: --long
     - Short options: -s
     - Option description
     - Default values
     - Type checking and error reporting
     - Available types: string, boolean, int, +int, float, +float
     - Type inference using the default value (when provided)
     - Automatic convertion of types (from strings)
     - Mandatory options and error reporting
     - Automatic help and version display (when turned on)

    Parsing:
        Values are assigned using an equal sign.
            --opt=val, -o=val
        Short options can be grouped together. The last
        option of a short option group can have a value:
            -abc=def c gets the value 'def'

         -a             => {a: true}
         -a=value       => {a: 'value'}
         -ab            => {a: true, b: true}
         -ab=value      => {a: true, b: 'value'}
         --long=value   => {long: 'value'}

         Anything that is not preceded by an option is considered
         a plain argument.