### PR TITLE
Create some ES5 runtime functions

### DIFF
--- a/source/runtime/runtime.js
+++ b/source/runtime/runtime.js
@@ -750,6 +750,28 @@ function $rt_toNumber(v)
 }
 
 /**
+http://www.ecma-international.org/ecma-262/5.1/#sec-9.4
+*/
+function $rt_toInteger(val)
+{
+    var number = $rt_toNumber(val);
+
+    // NaN
+    if (number !== number) return +0;
+
+    // -0, +0, -Infinity, Infinity
+    if (number === 0 ||
+        number === Infinity ||
+        number === -Infinity)
+    {
+            return number;
+    }
+
+    var sign = number < 0 ? -1 : 1;
+    return sign * Math.floor(Math.abs(number));
+}
+
+/**
 Convert any value to a signed 32-bit integer
 */
 function $rt_toInt32(x)

--- a/source/runtime/runtime.js
+++ b/source/runtime/runtime.js
@@ -517,7 +517,7 @@ function $rt_concatRope(rope, rightStr)
     {
         // The right-hand node must be a string
         var rightLen = $rt_str_get_len(rightStr);
-       
+
         // Right string data pointers
         var dataI = $ir_add_ptr_i32(rightStr, $rt_str_ofs_data(null, 0));
         var idxI = $ir_lsft_i32(rightLen, 1);
@@ -633,6 +633,27 @@ function $rt_toString(v)
     }
 
     assert (false, "unhandled type in toString");
+}
+
+/**
+http://www.ecma-international.org/ecma-262/5.1/#sec-9.9
+*/
+function $rt_toObject(arg)
+{
+    if (arg === null || arg === undefined)
+        throw new TypeError("Cannot be null or undefined");
+
+    switch (typeof(arg))
+    {
+        case 'boolean':
+            return new Boolean(arg);
+        case 'number':
+            return new Number(arg);
+        case 'string':
+            return new String(arg);
+    }
+
+    return arg;
 }
 
 /**
@@ -1708,7 +1729,7 @@ function $rt_eq(x, y)
             return $ir_eq_const(x, y);
 
         // undefined == null
-        if ($ir_eq_const(x, undefined) && 
+        if ($ir_eq_const(x, undefined) &&
             $ir_is_refptr(y) && $ir_eq_refptr(y, null))
             return true;
     }
@@ -2201,7 +2222,7 @@ function $rt_getProp(base, prop)
     if ($ir_is_string(base))
     {
         // If the property is a non-negative integer
-        if ($ir_is_int32(prop) && $ir_ge_i32(prop, 0) && 
+        if ($ir_is_int32(prop) && $ir_ge_i32(prop, 0) &&
             $ir_lt_i32(prop, $rt_str_get_len(base)))
         {
             var ch = $rt_str_get_data(base, prop);
@@ -3169,4 +3190,3 @@ function $rt_getPropEnum(curObj, propName, propIdx)
     // Fall back to the array element read
     return $rt_getPropElem(curObj, propName);
 }
-

--- a/source/stdlib/object.js
+++ b/source/stdlib/object.js
@@ -472,10 +472,7 @@ Object.assign = function (target)
 {
     // TODO symbol
 
-    if (target === null || target === undefined)
-        throw new TypeError("First source cannot be null or undefined");
-
-    var to = Object(target);
+    var to = $rt_toObject(target);
 
     for (var i = 1; i < arguments.length; i++)
     {
@@ -483,7 +480,7 @@ Object.assign = function (target)
 
         if (arg === null || arg === undefined) continue;
 
-        var src = Object(arg);
+        var src = $rt_toObject(arg);
 
         // Own enumables properties
         var keys = Object.keys(src);

--- a/source/tests/00-runtime/runtime.js
+++ b/source/tests/00-runtime/runtime.js
@@ -1,0 +1,23 @@
+require('lib/test');
+
+function test_$rt_toObject()
+{
+    assertThrows(function () {
+        $rt_toObject(null);
+    });
+
+    assertThrows(function () {
+        $rt_toObject(undefined);
+    });
+
+    assert($rt_toObject(true) instanceof Boolean);
+    assert($rt_toObject(3) instanceof Number);
+    assert($rt_toObject('abc') instanceof String);
+
+    var o = {};
+    assert($rt_toObject(o) === o);
+    var a = [];
+    assert($rt_toObject(a) === a);
+}
+
+test_$rt_toObject();

--- a/source/tests/00-runtime/runtime.js
+++ b/source/tests/00-runtime/runtime.js
@@ -20,4 +20,19 @@ function test_$rt_toObject()
     assert($rt_toObject(a) === a);
 }
 
+function test_$rt_toInteger()
+{
+    // ensure +0
+    assert(1/$rt_toInteger(NaN) === Infinity);
+    assert(1/$rt_toInteger(+0) === Infinity);
+    assert(1/$rt_toInteger(-0) === -Infinity);
+    assert($rt_toInteger(Infinity) === Infinity);
+    assert($rt_toInteger(-Infinity) === -Infinity);
+
+    assert($rt_toInteger(3.14) === 3);
+    assert($rt_toInteger(-3.14) === -3);
+    assert($rt_toInteger(3) === 3);
+}
+
 test_$rt_toObject();
+test_$rt_toInteger();

--- a/source/tests/01-stdlib/object.js
+++ b/source/tests/01-stdlib/object.js
@@ -486,6 +486,14 @@ function test_assign()
         assert(o.b === 1);
         assert(r.b === 1);
     })();
+
+    // Test with primitive
+    (function ()
+    {
+        var r = Object.assign(true, {a: 1, b: 2});
+        assert(r.a === 1);
+        assert(r.b === 2);
+    })();
 }
 
 function test_toString()


### PR DESCRIPTION
I need additional internal/runtime functions in order to implement elements of the ES6 draft. Those functions were included in the ES5 spec, but were not currently implemented in the runtime. This PR contains [ToInteger](https://es5.github.io/#x9.4), [ToObject](https://es5.github.io/#x9.9) and a commit that changes `Object.assign` to use those new functions.