### PR TITLE
Options parser changes

### DIFF
--- a/examples/options.js
+++ b/examples/options.js
@@ -1,15 +1,11 @@
-var Options = require('lib/options').Options;
-var console = require('lib/console')
+var options = require('lib/options');
+var console = require('lib/console');
 
-var o = Options()
-    // turn on automatic display of help
-    .autoHelp()
-    // turn on automatic display of version
-    .autoVersion()
+options
     // set version number
-    .version('1.0.0')
+    .setVersion('1.0.0')
     // set the usage string
-    .usage('file1, file2, fileN')
+    .setUsage('file1, file2, fileN')
     // long option only
     .add('long', null, null, 'long option.')
     // long and short option
@@ -21,8 +17,6 @@ var o = Options()
 
 // alternate construction
 // var o = Options({
-//     autoHelp: true,
-//     autoVersion: true,
 //     version: '1.0.0',
 //     usage: 'file1, file2, fileN',
 //     opts: [
@@ -37,7 +31,7 @@ var o = Options()
 // Both the long and short option will contain the value.
 // The plain arguments are placed in an array that
 // can be accessed via the _ property on the result.
-var r = o.parse(arguments);
+var r = options.parse(arguments);
 
 // display the resulting object
 console.log(r);

--- a/examples/turing-turtle.js
+++ b/examples/turing-turtle.js
@@ -16,7 +16,7 @@ var std = require('lib/stdlib');
 var draw = require('lib/draw');
 var image = require('lib/image');
 var rnd = require('lib/random');
-var Options = require('lib/options').Options;
+var options = require('lib/options');
 
 // ===========================================================================
 
@@ -267,12 +267,10 @@ Machine.prototype.update = function (numItrs)
 // ===========================================================================
 
 // Parse the command line arguments
-var o = Options()
-    .autoHelp()
-    .autoVersion()
+options
     .add('width' , 600, '+int', 'canvas width', 'w')
     .add('height', 600, '+int', 'canvas height', 'h');
-var args = o.parse(arguments);
+var args = options.parse(arguments);
 var canvasWidth  = args.width;
 var canvasHeight = args.height;
 
@@ -410,4 +408,3 @@ window.canvas.drawText(20, 120, "Left arrow to restart");
 
 // Show the drawing window
 window.show();
-

--- a/source/lib/options.js
+++ b/source/lib/options.js
@@ -147,7 +147,7 @@
     exports.help = help;
 
     /**
-     * long: long option name
+     * long: long option name (or an object with these params as keys)
      * short: short option name
      * desc: description of option
      * defval: default value
@@ -156,6 +156,15 @@
      */
     function add(long, defval, type, desc, short, req)
     {
+        if (arguments.length === 1 && long !== null && typeof(long) === "object") {
+            var opts = long;
+            long = opts.long;
+            defval = opts.defval;
+            type = opts.type;
+            desc = opts.desc;
+            short = opts.short;
+            req = opts.req;
+        }
         // try to infer the type when possible
         if (type == null)
         {

--- a/source/lib/options.js
+++ b/source/lib/options.js
@@ -32,74 +32,54 @@
 (function (exports) {
 
     var exit = require('lib/stdlib').exit;
+    var inst = {
+        _usage: null,
+        _version: null,
+        _specs: [],
+        _helpSpec: {long: 'help', short: null, desc: 'display this help and exit', defval: false, type: 'boolean'},
+        _versionSpec: {long: 'version', short: null, desc: "output version information and exit", defval: false, type: 'boolean'},
+     };
 
     /**
      * Create a new options parser.
      * config: (optional)
      */
-    function Options(config)
+    function setConfig(config)
     {
-        if (!(this instanceof Options)) return new Options(config);
-        this._usage = null;
-        this._version = null;
-        this._specs = [];
-
-        this.helpSpec = {long: 'help', short: null, desc: 'display this help and exit', defval: false, type: 'boolean'};
-        this.versionSpec = {long: 'version', short: null, desc: "output version information and exit", defval: false, type: 'boolean'};
-
         if (config != null)
         {
-            this._usage = config.usage;
-            this._version = config.version;
-            this._autoHelp = config.autoHelp;
-            this._autoVersion = config.autoVersion;
+            inst._usage = config.usage;
+            inst._version = config.version;
             for (var i = 0; i < config.opts.length; i++)
             {
                 var opt = config.opts[i];
-                this.add(opt.long, opt.defval, opt.type, opt.desc, opt.short, opt.req);
+                add(opt.long, opt.defval, opt.type, opt.desc, opt.short, opt.req);
             }
         }
+
+        return exports;
     }
+    exports.setConfig = setConfig;
 
     /**
      * usage: usage string
      */
-    Options.prototype.usage = function (usage)
+    function setUsage(usage)
     {
-        this._usage = usage;
-        return this;
+        inst._usage = usage;
+        return exports;
     };
+    exports.setUsage = setUsage;
 
     /**
      * version: version string
      */
-    Options.prototype.version = function (version)
+    function setVersion(version)
     {
-        this._version = version;
-        return this;
+        inst._version = version;
+        return exports;
     };
-
-    /**
-     * Turn automatic display of help on or off.
-     * on: (optional, defaults to true)
-     */
-    Options.prototype.autoHelp = function (on)
-    {
-        if (on == null) on = true;
-        this._autoHelp = on;
-        return this;
-    };
-
-    /**
-     * Turn automatic display of version on of off.
-     * on: (optional, defaults to true)
-     */
-    Options.prototype.autoVersion = function (on)
-    {
-        if (on == null) on = true;
-        this._autoVersion = on;
-        return this;
-    }
+    exports.setVersion = setVersion;
 
     /**
      * Format a spec for display.
@@ -126,13 +106,13 @@
     /**
      * Display help about command.
      */
-    Options.prototype.help = function ()
+    function help()
     {
         var buff = '';
-        var specs = this._getSpecs();
+        var specs = getSpecs();
 
-        if (this._usage != null)
-            buff += '\nUsage: ' + this._usage +'\n';
+        if (inst._usage != null)
+            buff += '\nUsage: ' + inst._usage +'\n';
 
         if (specs.length > 0)
         {
@@ -164,6 +144,7 @@
 
         print(buff);
     };
+    exports.help = help;
 
     /**
      * long: long option name
@@ -173,7 +154,7 @@
      * type: type of data (valid types: string, int, +int, float, +float, boolean)
      * req: required
      */
-    Options.prototype.add = function (long, defval, type, desc, short, req)
+    function add(long, defval, type, desc, short, req)
     {
         // try to infer the type when possible
         if (type == null)
@@ -196,7 +177,7 @@
             }
         }
 
-        this._specs.push({
+        inst._specs.push({
             long: long,
             short: short,
             desc: desc,
@@ -205,21 +186,85 @@
             req: req,
         });
 
-        return this;
+        return exports;
     };
+    exports.add = add;
+
+    /**
+     * args: command line arguments
+     *
+     * Accepted patterns for parameters:
+     *  -a             => {a: true}
+     *  -ab            => {a: true, b: true}
+     *  -ab=value      => {a: true, b: value}
+     *  --long=value   => {long: value}
+     */
+    function parse(argv)
+    {
+        var p = parseArgv(argv);
+        var opts = p.opts;
+        var results = {};
+        var specs = getSpecs();
+        for (var i = 0; i < specs.length; i++)
+        {
+            var spec = specs[i];
+            // check if long option is present
+            var val = getValue(opts, spec);
+
+            // if there is a value, use it
+            if (val != null)
+            {
+                // validate value
+                if ((typeof val === 'boolean' && spec.type !== 'boolean') || !typeTests[spec.type](val))
+                {
+                    printAndExit('Invalid type for ' + formatSpec(spec) + '. Expected ' + typeToString[spec.type] + ".");
+                }
+
+                // convert from string to spec.type
+                val = convertValue(val, spec.type);
+
+                applyValue(results, spec, val);
+            }
+            // fallback to default value if present
+            else if (spec.defval != null)
+            {
+                applyValue(results, spec, spec.defval);
+            }
+            else if (spec.req === true)
+            {
+                printAndExit('The option ' + formatSpec(spec) + ' is required.');
+            }
+        }
+
+        results._ = p.args;
+
+        if (results.help === true)
+        {
+            help();
+            exit(0);
+        }
+
+        if (inst._version != null && results.version === true)
+        {
+            printAndExit(inst._version, 0);
+        }
+
+        return results;
+    };
+    exports.parse = parse;
 
     /**
      * Get the list of specs and append the helpSpec and versionSpec if they're activated.
      */
-    Options.prototype._getSpecs = function ()
+    function getSpecs()
     {
-        var arr = this._specs.slice();
-        if (this._autoHelp)
-            arr = arr.concat(this.helpSpec);
-        if (this._autoVersion && this._version != null)
-            arr = arr.concat(this.versionSpec);
+        var arr = inst._specs.slice();
+        if (inst._usage != null)
+            arr = arr.concat(inst._helpSpec);
+        if (inst._version != null)
+            arr = arr.concat(inst._versionSpec);
         return arr;
-    };
+    }
 
     /**
      * arg: argument to parse
@@ -425,69 +470,5 @@
         print(str);
         exit(code != null ? code : 1);
     }
-
-    /**
-     * args: command line arguments
-     *
-     * Accepted patterns for parameters:
-     *  -a             => {a: true}
-     *  -ab            => {a: true, b: true}
-     *  -ab=value      => {a: true, b: value}
-     *  --long=value   => {long: value}
-     */
-    Options.prototype.parse = function (argv)
-    {
-        var p = parseArgv(argv);
-        var opts = p.opts;
-        var results = {};
-        var specs = this._getSpecs();
-        for (var i = 0; i < specs.length; i++)
-        {
-            var spec = specs[i];
-            // check if long option is present
-            var val = getValue(opts, spec);
-
-            // if there is a value, use it
-            if (val != null)
-            {
-                // validate value
-                if ((typeof val === 'boolean' && spec.type !== 'boolean') || !typeTests[spec.type](val))
-                {
-                    printAndExit('Invalid type for ' + formatSpec(spec) + '. Expected ' + typeToString[spec.type] + ".");
-                }
-
-                // convert from string to spec.type
-                val = convertValue(val, spec.type);
-
-                applyValue(results, spec, val);
-            }
-            // fallback to default value if present
-            else if (spec.defval != null)
-            {
-                applyValue(results, spec, spec.defval);
-            }
-            else if (spec.req === true)
-            {
-                printAndExit('The option ' + formatSpec(spec) + ' is required.');
-            }
-        }
-
-        results._ = p.args;
-
-        if (this._autoHelp && results.help === true)
-        {
-            this.help();
-            exit(0);
-        }
-
-        if (this._autoVersion && this._version != null && results.version === true)
-        {
-            printAndExit(this._version, 0);
-        }
-
-        return results;
-    };
-
-    exports.Options = Options;
 
 })(exports);

--- a/source/tests/09-lib/options.js
+++ b/source/tests/09-lib/options.js
@@ -5,6 +5,11 @@ if (typeof assertEq === 'undefined')
 
 var options = require('lib/options.js');
 
+function reset()
+{
+    delete require.loaded['lib/options.js'];
+}
+
 function test_parseArgv()
 {
     var argv = ['arg1', '--longbool', '--longval=val', '-abc', 'arg2', '-def=val'];
@@ -25,7 +30,9 @@ function test_parseArgv()
 
 function test_parse_result()
 {
-    var o = options.Options()
+    reset();
+
+    var o = require('lib/options.js')
         .add('long', null)
         .add('double', null, null, null, 'd')
         .add(null, null, 'boolean', null, 's');
@@ -41,7 +48,9 @@ function test_parse_result()
 
 function test_parse_defval()
 {
-    var o = options.Options()
+    reset();
+
+    var o = require('lib/options.js')
         .add('default', 'qwerty', null, null, 'D');
 
     var r = o.parse([]);
@@ -52,7 +61,9 @@ function test_parse_defval()
 
 function test_parse_convert()
 {
-    var o = options.Options()
+    reset();
+
+    var o = require('lib/options.js')
         .add('intval', null, 'int')
         .add('floatval', null, 'float')
         .add('yes', null, 'boolean')


### PR DESCRIPTION
Did a few changes. Removed `autoHelp` and `autoVersion`. Changed `usage` to `setUsage` and `version` to `setVersion`. Changed the constructor to `setConfig` for the ones that want to configure everything in a big block. Also allowed `add` to use objects, like in `setConfig`.