### PR TITLE
drawPoint FP to int round and conversion

### DIFF
--- a/source/lib/draw.js
+++ b/source/lib/draw.js
@@ -439,6 +439,21 @@ lib/draw - provides basic drawing API using xlib
     */
     CanvasProto.drawPoint = function(x, y)
     {
+        // Convert FP values to int for xy coordinates.
+        if (!($ir_is_int32(x)) || !($ir_is_int32(y)))              
+        {
+            // Round and convert to Int32
+            if (x + .5 >= x | 0 + 1)
+                x = $rt_toInt32(x) + 1;
+            else
+                x = $rt_toInt32(x);
+                
+            if (y + .5 >= y | 0 + 1)
+                y = $rt_toInt32(y) + 1;
+            else
+                y = $rt_toInt32(y);
+        }
+        
         Xlib.XDrawPoint(this.display, this.id, this.gc, x, y);
     };
 

--- a/source/lib/draw.js
+++ b/source/lib/draw.js
@@ -439,19 +439,14 @@ lib/draw - provides basic drawing API using xlib
     */
     CanvasProto.drawPoint = function(x, y)
     {
-        // Convert FP values to int for xy coordinates.
-        if (!($ir_is_int32(x)) || !($ir_is_int32(y)))              
+        // Convert FP to int
+        if (!$ir_is_int32(x))
         {
-            // Round and convert to Int32
-            if (x + .5 >= x | 0 + 1)
-                x = $rt_toInt32(x) + 1;
-            else
-                x = $rt_toInt32(x);
-                
-            if (y + .5 >= y | 0 + 1)
-                y = $rt_toInt32(y) + 1;
-            else
-                y = $rt_toInt32(y);
+            x = $rt_toInt32(x);
+        }
+        if (!$ir_is_int32(y))
+        {
+            y = rt_toInt32(y);
         }
         
         Xlib.XDrawPoint(this.display, this.id, this.gc, x, y);


### PR DESCRIPTION
Notes: Addresses Issue #130 

-This seems to work well on the drawPoint function. I tested it with turing-turtle(removed the posX / posY conversion first) and all seemed well.

-Each if else block for x and y can be done as two ternary clauses,
but for clarity, they're currently all spelled out.

-This should be contained as it's own function, and possiblly applied to draw lib functions by
users as an optional arg like drawPoint(10, 10, convertFP).

-I'm open to advice on simplifying and improving this more, and on the best way to implement it across the whole draw lib (without excessive repetition).