### PR TITLE
update dmd depecated module names/locatons

### DIFF
--- a/source/ir/ast.d
+++ b/source/ir/ast.d
@@ -37,6 +37,7 @@
 
 module ir.ast;
 
+import stats;
 import std.ascii;
 import std.stdint;
 import std.stdio;

--- a/source/jit/ops.d
+++ b/source/jit/ops.d
@@ -39,7 +39,7 @@ module jit.ops;
 
 import core.memory;
 import core.stdc.string;
-import std.c.math;
+import core.stdc.math;
 import std.stdio;
 import std.string;
 import std.array;
@@ -628,15 +628,15 @@ void HostFPOp(alias cFPFun, size_t arity = 1)(
     ctx.setOutTag(as, instr, Tag.FLOAT64);
 }
 
-alias gen_sin_f64 = HostFPOp!(std.c.math.sin);
-alias gen_cos_f64 = HostFPOp!(std.c.math.cos);
-alias gen_sqrt_f64 = HostFPOp!(std.c.math.sqrt);
-alias gen_ceil_f64 = HostFPOp!(std.c.math.ceil);
-alias gen_floor_f64 = HostFPOp!(std.c.math.floor);
-alias gen_log_f64 = HostFPOp!(std.c.math.log);
-alias gen_exp_f64 = HostFPOp!(std.c.math.exp);
-alias gen_pow_f64 = HostFPOp!(std.c.math.pow, 2);
-alias gen_mod_f64 = HostFPOp!(std.c.math.fmod, 2);
+alias gen_sin_f64 = HostFPOp!(core.stdc.math.sin);
+alias gen_cos_f64 = HostFPOp!(core.stdc.math.cos);
+alias gen_sqrt_f64 = HostFPOp!(core.stdc.math.sqrt);
+alias gen_ceil_f64 = HostFPOp!(core.stdc.math.ceil);
+alias gen_floor_f64 = HostFPOp!(core.stdc.math.floor);
+alias gen_log_f64 = HostFPOp!(core.stdc.math.log);
+alias gen_exp_f64 = HostFPOp!(core.stdc.math.exp);
+alias gen_pow_f64 = HostFPOp!(core.stdc.math.pow, 2);
+alias gen_mod_f64 = HostFPOp!(core.stdc.math.fmod, 2);
 
 void FPToStr(string fmt)(
     BlockVersion ver,

--- a/source/main.d
+++ b/source/main.d
@@ -38,8 +38,8 @@
 import core.sys.posix.signal;
 import core.stdc.signal;
 import core.memory;
-import std.c.string;
-import std.c.stdlib;
+import core.stdc.string;
+import core.stdc.stdlib;
 import std.stdio;
 import std.file;
 import std.algorithm;

--- a/source/runtime/gc.d
+++ b/source/runtime/gc.d
@@ -38,8 +38,8 @@
 module runtime.gc;
 
 import core.memory;
-import std.c.stdlib;
-import std.c.string;
+import core.stdc.stdlib;
+import core.stdc.string;
 import std.stdint;
 import std.stdio;
 import std.string;

--- a/source/runtime/string.d
+++ b/source/runtime/string.d
@@ -37,7 +37,7 @@
 
 module runtime.string;
 
-import std.c.string;
+import core.stdc.string;
 import std.stdio;
 import std.stdint;
 import std.string;

--- a/source/runtime/vm.d
+++ b/source/runtime/vm.d
@@ -38,7 +38,7 @@
 module runtime.vm;
 
 import core.memory;
-import std.c.string;
+import core.stdc.string;
 import std.stdio;
 import std.string;
 import std.array;


### PR DESCRIPTION
This PR eliminates all deprecated module warnings except for the one related to currAppTick.

@maximecb I left work on MonoTime out of this PR. I think it's a good idea to introduce the new timing functionality under a new Issue/PR in order to more distinctly isolate those changes. 

I had one concern over where I added `import stats` to `ir/ast.d`
This is to eliminate:
```
ir/ast.d(360): Deprecation: runtime.vm.stats is not visible from module ast
```
where the line 360 above increments numFunsComp:
```
stats.numFunsComp++
```