### PR TITLE
Revert "move import stats.d for code style organization"

### DIFF
--- a/source/ir/ast.d
+++ b/source/ir/ast.d
@@ -37,6 +37,7 @@
 
 module ir.ast;
 
+import stats;
 import std.ascii;
 import std.stdint;
 import std.stdio;
@@ -56,7 +57,6 @@ import ir.livevars;
 import ir.slotalloc;
 import runtime.vm;
 import options;
-import stats;
 
 /**
 IR generation context


### PR DESCRIPTION
Build fails when moving import stats, reverting and testing

Reverts higgsjs/Higgs#209