### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM dlanguage/dmd:2.073.2
+
+COPY . /src/
+
+WORKDIR /src/source
+
+RUN apt-get update \
+ && apt-get install -y build-essential python \
+ && make all \
+ && apt-get auto-remove
+
+ENTRYPOINT ["/src/source/higgs"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ A JIT compiler for JavaScript targetting x86-64 platforms.
 
 **Quickstart:**
 
+*Precompiled Docker Image*
+
+Higgs could be used as docker image.
+
+Run `docker run -ti dlanguage/higgs` for the Higgs REPL.
+Run `docker run -ti -v $(pwd):/work -w /work dlanguage/higgs your_local_file.js` to evaluate a local .js-file.
+
 *Get the source:*
 
 `git clone https://github.com/higgsjs/Higgs.git && cd Higgs/source`


### PR DESCRIPTION
Docker support eases the first five minutes with Higgs. People just could use Higgs without dealing about the often troublesome compilation process.