### PR TITLE
Remove destructor from IRFunction

### DIFF
--- a/source/ir/ir.d
+++ b/source/ir/ir.d
@@ -177,12 +177,6 @@ class IRFunction : IdObject
         }
     }
 
-    /// Destructor
-    ~this()
-    {
-        //writeln("destroying fun");
-    }
-
     /// Test if this is a unit-level function
     bool isUnit() const
     {


### PR DESCRIPTION
@andralex is proposing a change to D's `destroy` implementation at https://github.com/dlang/druntime/pull/2126

The new semantics re-initialize an instance if it has a user-defined destructor.  This breaks Higgs as shown in the output of D's Jenkins CI (https://ci.dlang.io/blue/organizations/jenkins/dlang-org%2Fdruntime/detail/PR-2126/1/pipeline/235)

Since `IRFunction`'s destructor does nothing, I think it is safe to delete, regardless of whether @andralex's proposed implementation of `destroy` is accepted or not.  And, D will be able to continue to test compatibility with Higgs in its CI.

cc @maximecb @sbstp