### PR TITLE
Fixes deprecation warnings from extra semi colons

### DIFF
--- a/source/jit/ops.d
+++ b/source/jit/ops.d
@@ -853,7 +853,7 @@ void TagTestOp(Tag tag)(
     if (opts.load_tag_tests)
     {
         // Get the type analysis result for this value at this instruction
-        auto anaResult = getTagTestResult(ver);;
+        auto anaResult = getTagTestResult(ver);
 
         //writeln("result: ", anaResult);
 

--- a/source/runtime/string.d
+++ b/source/runtime/string.d
@@ -187,7 +187,7 @@ uint64_t murmurHash64A(const void* key, size_t len, uint64_t seed = 1337)
         case 1: h ^= (cast(uint64_t)tail[0]);
                 h *= m;  goto default;
         default:
-    };
+    }
 
     h ^= h >> r;
     h *= m;


### PR DESCRIPTION
When compiling with DMD64 D Compiler v2.080.0, the following depreciation warnings are received: 
```
runtime/string.d(190): Deprecation: use { } for an empty statement, not ;
jit/ops.d(856): Deprecation: use { } for an empty statement, not ;
```
By removing the two semi-colons in question, the warnings are fixed.