### PR TITLE
Make compatible with `-dip25`

### DIFF
--- a/source/jit/util.d
+++ b/source/jit/util.d
@@ -336,7 +336,7 @@ void saveAllocRegs(CodeBlock as)
     assert (scrRegs[0] == RAX);
     as.mov(scrRegs[0], &vm.regSave);
 
-    foreach (uint regIdx, reg; allocRegs)
+    foreach (const regIdx, reg; allocRegs)
     {
         //as.printStr("save " ~ reg.toString);
         //as.printUint(reg.opnd);
@@ -356,7 +356,7 @@ void loadAllocRegs(CodeBlock as)
     assert (scrRegs[0] == RAX);
     as.mov(scrRegs[0], &vm.regSave);
 
-    foreach (uint regIdx, reg; allocRegs)
+    foreach (const regIdx, reg; allocRegs)
     {
         auto memOpnd = X86Opnd(64, scrRegs[0], 8 * regIdx);
         as.mov(reg.opnd, memOpnd);

--- a/source/makefile
+++ b/source/makefile
@@ -12,11 +12,11 @@ else
 	LIBS := -L-ldl
 endif
 
-COPTS := -m64 -O -J./
-TESTOPTS := -m64 -O -J./ -unittest -debug
-DBGOPTS := -m64 -O  -J./ -gc -debug
-RELOPTS := -m64 -O -J./ -release -inline -boundscheck=off -version=release
-PROFOPTS := -m64 -O -J./ -release -inline -boundscheck=off -profile
+COPTS := -m64 -O -J./ -dip25
+TESTOPTS := -m64 -O -J./ -unittest -debug -dip25
+DBGOPTS := -m64 -O  -J./ -gc -debug -dip25
+RELOPTS := -m64 -O -J./ -release -inline -boundscheck=off -version=release -dip25
+PROFOPTS := -m64 -O -J./ -release -inline -boundscheck=off -profile -dip25
 
 BIN_NAME = higgs
 BIN_NAME_TEST = higgs-test

--- a/source/runtime/gc.d
+++ b/source/runtime/gc.d
@@ -94,7 +94,7 @@ struct GCRoot
         //writeln("GCRoot destructor done");
     }
 
-    GCRoot* opAssign(ValuePair v)
+    GCRoot* opAssign(ValuePair v) return
     {
         // If the new pointer is non-null and this root isn't listed yet
         if (v.word.ptrVal && !ptr)
@@ -142,7 +142,7 @@ struct GCRoot
         return &this;
     }
 
-    GCRoot* opAssign(GCRoot v)
+    GCRoot* opAssign(GCRoot v) return
     {
         this = v.pair;
         return &this;


### PR DESCRIPTION
And prevent a deprecation message related to type of loop index. Support for -dip25 is added because of https://github.com/dlang/dmd/pull/9154.