### PR TITLE
Add toHash method for struct runtime/object/ValType

### DIFF
--- a/source/runtime/object.d
+++ b/source/runtime/object.d
@@ -303,6 +303,17 @@ struct ValType
         return true;
     }
 
+    // Hashing operator that does memberwise hashing
+    size_t toHash() const nothrow
+    {
+        size_t h = 0;
+        foreach(i, T; typeof(this.tupleof))
+        {
+            h = h * 33 + typeid(T).getHash(cast(const void*)&this.tupleof[i]);
+        }
+        return h;
+    }
+
     /**
     Compute the union with another type
     */


### PR DESCRIPTION
This is currently blocking [1]. In dmd, if you define use a `struct` as a key for an associative array and you define opEquals you have to define toHash also; before [1], due to a compiler bug regarding anonymous unions the compiler generated a builtin toHash method for `ValType`, now it no longer does that causing an error. This patch explicitly adds the builtin toHash method for structs to ValType.

After this is merged, please push a new tag so buildkite can pick it up and test against the latest version. Thanks!

[1] https://github.com/dlang/dmd/pull/9909