### PR TITLE
Fix build for python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A JIT compiler for JavaScript targetting x86-64 platforms.
 
 - D compiler (latest [DMD](http://dlang.org/download.html) recommended)
 - POSIX compliant OS (Linux, Unix, MacOS X)
-- Python 2.7 (if regenerating object layouts)
+- Python 3.x (if regenerating object layouts)
 - x86 64-bit CPU
 - 2 GB of RAM
 - GNU make
@@ -32,7 +32,7 @@ Run `docker run -ti -v $(pwd):/work -w /work dlanguage/higgs your_local_file.js`
 
 NOTE: if you run a non-Linux OS like FreeBSD you may not have `GNU make` installed. You may need to install the "gmake" package or otherwise acquire `GNU make`.
 
-NOTE: if your default python version is 3.x, just append `PYTHON=$PATH_TO_PYTHON2` to the `make` commands
+NOTE: it is possible to customize the Python version used by appending `PYTHON=$PATH_TO_PYTHON` to the `make` commands
 
 `make all`
 generates a binary `higgs` in the source directory.

--- a/source/makefile
+++ b/source/makefile
@@ -1,6 +1,6 @@
 DC = dmd
 ifndef PYTHON
-	PYTHON = python
+	PYTHON = python3
 endif
 # compiler options
 UNAME := $(shell uname)

--- a/source/runtime/layout.py
+++ b/source/runtime/layout.py
@@ -192,7 +192,8 @@ def indent(input, indentStr = '    '):
     return output
 
 def sepList(lst, sep = ', '):
-    if len(lst) == 0:
+    from functools import reduce
+    if len(list(lst)) == 0:
         return ''
     return reduce(lambda x,y: x + sep + y, lst)
 
@@ -264,7 +265,7 @@ class Function:
         params = self.params
         if len(params) >= 1 and params[0].name == 'vm':
             params = params[1:]
-        out += sepList(map(lambda v:v.genJS(), params))
+        out += sepList(list(map(lambda v:v.genJS(), params)))
         out += ')\n'
         out += '{'
         stmts = ''
@@ -277,7 +278,7 @@ class Function:
     def genD(self):
         out = ''
         out += 'extern (C) ' + self.type + ' ' + self.name + '('
-        out += sepList(map(lambda v:v.genDeclD(), self.params))
+        out += sepList(list(map(lambda v:v.genDeclD(), self.params)))
         out += ')\n'
         out += '{'
         stmts = ''
@@ -466,13 +467,13 @@ class CallExpr:
 
     def genJS(self):
         out = JS_DEF_PREFIX + self.fName + '('
-        out += sepList(map(lambda v:v.genJS(), self.args))
+        out += sepList(list(map(lambda v:v.genJS(), self.args)))
         out += ')'
         return out
 
     def genD(self):
         out = self.fName + '('
-        out += sepList(map(lambda v:v.genD(), self.args))
+        out += sepList(list(map(lambda v:v.genD(), self.args)))
         out += ')'
         return out
 


### PR DESCRIPTION
Dlang's Buildkite no longer supports python2 (https://github.com/dlang/ci/pull/479) but we still want to keep this project there.